### PR TITLE
Terrain generation 1: Terrain chunks

### DIFF
--- a/Assets/Scenes/TerrainGenerationTesting.unity
+++ b/Assets/Scenes/TerrainGenerationTesting.unity
@@ -324,8 +324,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7339f76633f1bc34baf59002888b5dc0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _chunkSize: 1
-  _viewDistance: 5
+  _chunkSize: 10
+  _viewDistance: 200
   _viewer: {fileID: 113356281}
 --- !u!1 &999304457
 GameObject:

--- a/Assets/Scenes/TerrainGenerationTesting.unity
+++ b/Assets/Scenes/TerrainGenerationTesting.unity
@@ -1,0 +1,602 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &113356280
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 113356281}
+  m_Layer: 0
+  m_Name: Viewer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &113356281
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113356280}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 166713526}
+  m_Father: {fileID: 1454056541}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &166713525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 166713526}
+  - component: {fileID: 166713529}
+  - component: {fileID: 166713528}
+  - component: {fileID: 166713527}
+  m_Layer: 0
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &166713526
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166713525}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 113356281}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &166713527
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166713525}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &166713528
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166713525}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &166713529
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166713525}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &177739564
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 177739565}
+  m_Layer: 0
+  m_Name: Cameras
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &177739565
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 177739564}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1712622151}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &632041161
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 632041162}
+  - component: {fileID: 632041163}
+  m_Layer: 0
+  m_Name: Terrain
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &632041162
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 632041161}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1454056541}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &632041163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 632041161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7339f76633f1bc34baf59002888b5dc0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _chunkSize: 1
+  _viewDistance: 5
+  _viewer: {fileID: 113356281}
+--- !u!1 &999304457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 999304458}
+  m_Layer: 0
+  m_Name: Lighting
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &999304458
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 999304457}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1929141258}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1454056540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1454056541}
+  m_Layer: 0
+  m_Name: World
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1454056541
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1454056540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 113356281}
+  - {fileID: 632041162}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1712622148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1712622151}
+  - component: {fileID: 1712622150}
+  - component: {fileID: 1712622149}
+  - component: {fileID: 1712622152}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1712622149
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712622148}
+  m_Enabled: 1
+--- !u!20 &1712622150
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712622148}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.24528301, g: 0.24528301, b: 0.24528301, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1712622151
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712622148}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 373, z: -799}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 177739565}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1712622152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712622148}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+--- !u!1 &1929141256
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1929141258}
+  - component: {fileID: 1929141257}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1929141257
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1929141256}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1929141258
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1929141256}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 999304458}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}

--- a/Assets/Scenes/TerrainGenerationTesting.unity.meta
+++ b/Assets/Scenes/TerrainGenerationTesting.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 614eb4fd73625e845b5d7a84386dab9d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Common.meta
+++ b/Assets/Scripts/Common.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e86b85f45488c140831b0bed15fca95
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Common/Pool.cs
+++ b/Assets/Scripts/Common/Pool.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PotentialRobot.Common
+{
+    public class Pool<T>
+    {
+        private readonly Func<T> _factoryMethod;
+        private readonly Func<T, T> _resetMethod;
+
+        private Stack<T> _pool;
+
+        public Pool(Func<T> factoryMethod, Func<T, T> resetMethod = null, int initialCount = 0)
+        {
+            _factoryMethod = factoryMethod;
+            _resetMethod = resetMethod;
+            InitPool(initialCount);
+        }
+
+        public T Lease()
+        {
+            if (!TryLease(out T item))
+                item = _factoryMethod();
+
+            return item;
+        }
+
+        public void Recycle(T item)
+        {
+            if (_resetMethod != null)
+                item = _resetMethod(item);
+
+            _pool.Push(item);
+        }
+
+        private void InitPool(int initialCount)
+        {
+            _pool = new Stack<T>();
+            for (int i = 0; i < initialCount; i++)
+                _pool.Push(_factoryMethod());
+        }
+
+        private bool TryLease(out T item)
+        {
+            if (_pool.Count > 0)
+            {
+                item = _pool.Pop();
+                return true;
+            }
+            else
+            {
+                item = default;
+                return false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Common/Pool.cs.meta
+++ b/Assets/Scripts/Common/Pool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9b49ff15b602d8468bdae660c259ecc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain.meta
+++ b/Assets/Scripts/Terrain.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9c907fe20aca5774cb42fe70eb06451b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/ChunkController.cs
+++ b/Assets/Scripts/Terrain/ChunkController.cs
@@ -1,117 +1,80 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using PotentialRobot.Terrain.Generation;
 using UnityEngine;
 
 namespace PotentialRobot.Terrain
 {
-    public class ChunkController
+    public class ChunkController : IChunkController
     {
-        private struct ChunkCoordinates
-        {
-            public int X { get; private set; }
-            public int Y { get; private set; }
-
-            public ChunkCoordinates(int x, int y)
-            {
-                X = x;
-                Y = y;
-            }
-
-            public static ChunkCoordinates operator +(ChunkCoordinates a, ChunkCoordinates b)
-                => new ChunkCoordinates(a.X + b.X, a.Y + b.Y);
-
-            public static ChunkCoordinates operator -(ChunkCoordinates a, ChunkCoordinates b)
-                => new ChunkCoordinates(a.X - b.X, a.Y - b.Y);
-        }
-
-        private readonly float _chunkSize;
-        private readonly float _viewDistance;
-        private readonly Transform _chunkParent;
-        private readonly List<GameObject> _chunks;
         private readonly IChunkProvider _chunkProvider;
+        private readonly ChunkVisibilityHelper _visibilityHelper;
+        private readonly ChunkPositionHelper _positionHelper;
+        private readonly Dictionary<ChunkCoordinates, GameObject> _chunks;
+
+        private const string ChunkNameFormat = "Chunk [{0},{1}]";
 
         public ChunkController(Transform chunkParent, float chunkSize, float viewDistance)
         {
-            _chunkParent = chunkParent;
-            _chunkSize = chunkSize;
-            _viewDistance = viewDistance;
-            _chunks = new List<GameObject>();
-            _chunkProvider = new ChunkProvider();
+            _chunkProvider = new ChunkProvider(chunkParent, chunkSize);
+            _visibilityHelper = new ChunkVisibilityHelper(chunkSize, viewDistance);
+            _positionHelper = new ChunkPositionHelper(chunkSize);
+            _chunks = new Dictionary<ChunkCoordinates, GameObject>();
         }
 
         public void UpdateChunkVisibility(Vector3 viewerPosition)
         {
-            CleanUpChunks();
-            CreateVisibleChunks(viewerPosition);
+            CleanUpOutOfViewDistanceChunks(viewerPosition);
+            CreateNewVisibleChunks(viewerPosition);
         }
 
-        private void CleanUpChunks()
+        private void CleanUpOutOfViewDistanceChunks(Vector3 viewerPosition)
         {
-            foreach (GameObject chunk in _chunks)
-                _chunkProvider.CleanUpChunk(chunk);
-        }
-
-        private void CreateVisibleChunks(Vector3 viewerPosition)
-        {
-            int viewDistanceInChunks = Mathf.RoundToInt(_viewDistance / _chunkSize);
-
-            for (int i = -viewDistanceInChunks; i <= viewDistanceInChunks; i++)
+            var cleanedUpCoordinates = new List<ChunkCoordinates>();
+            foreach (KeyValuePair<ChunkCoordinates, GameObject> chunk in _chunks)
             {
-                for (int j = -viewDistanceInChunks; j <= viewDistanceInChunks; j++)
-                {
-                    var chunkOffset = new ChunkCoordinates(i, j);
-                    ChunkCoordinates chunkCoordinates = ChunkCoordinatesFromOffset(viewerPosition, chunkOffset);
-                    CreateChunkIfVisible(chunkCoordinates, viewerPosition);
-                }
+                if (CleanUpIfNotVisible(chunk.Key, chunk.Value, viewerPosition))
+                    cleanedUpCoordinates.Add(chunk.Key);
+            }
+
+            foreach (ChunkCoordinates coordinates in cleanedUpCoordinates)
+                _ = _chunks.Remove(coordinates);
+        }
+
+        private bool CleanUpIfNotVisible(ChunkCoordinates coordinates, GameObject chunk, Vector3 viewerPosition)
+        {
+            Vector3 chunkPosition = _positionHelper.CoordinatesToPosition(coordinates);
+            if (_visibilityHelper.IsVisible(chunkPosition, viewerPosition))
+                return false;
+
+            _chunkProvider.CleanUpChunk(chunk);
+            return true;
+        }
+
+        private void CreateNewVisibleChunks(Vector3 viewerPosition)
+        {
+            ChunkCoordinates viewerCoordinates = _positionHelper.PositionToCoordinates(viewerPosition);
+
+            foreach (ChunkCoordinates coordinates in _visibilityHelper
+                .GetPotentiallyVisibleCoordinates(viewerCoordinates))
+            {
+                if (_chunks.ContainsKey(coordinates))
+                    continue;
+
+                Vector3 chunkPosition = _positionHelper.CoordinatesToPosition(coordinates);
+                if (_visibilityHelper.IsVisible(chunkPosition, viewerPosition))
+                    CreateChunk(coordinates, chunkPosition);
             }
         }
 
-        private ChunkCoordinates ChunkCoordinatesFromOffset(Vector3 viewerPosition, ChunkCoordinates chunkOffsetFromViewer)
+        private void CreateChunk(ChunkCoordinates coordinates, Vector3 position)
         {
-            ChunkCoordinates viewerCoordinates = PositionToChunkCoordinate(viewerPosition);
-            return viewerCoordinates + chunkOffsetFromViewer;
+            GameObject newChunk = _chunkProvider.GetChunk(position);
+            newChunk.name = GetChunkName(coordinates);
+            _chunks.Add(coordinates, newChunk);
         }
 
-        private ChunkCoordinates PositionToChunkCoordinate(Vector3 position)
-        {
-            int coordinateX = Mathf.RoundToInt(position.z / _chunkSize);
-            int coordinateY = Mathf.RoundToInt(position.x / _chunkSize);
-
-            return new ChunkCoordinates(coordinateX, coordinateY);
-        }
-
-        private void CreateChunkIfVisible(ChunkCoordinates coordinates, Vector3 viewerPosition)
-        {
-            Vector3 chunkPosition = CalculateChunkPosition(coordinates);
-            if (IsChunkVisible(chunkPosition, viewerPosition))
-                CreateChunk(chunkPosition);
-        }
-
-        private Vector3 CalculateChunkPosition(ChunkCoordinates coordinates)
-        {
-            float chunkX = coordinates.Y * _chunkSize;
-            float chunkY = 0;
-            float chunkZ = coordinates.X * _chunkSize;
-
-            return new Vector3(chunkX, chunkY, chunkZ);
-        }
-
-        /// <summary>
-        /// Calculates distance to chunk center, 
-        /// instead of distance to nearest point in chunk.
-        /// </summary>
-        private bool IsChunkVisible(Vector3 chunkPosition, Vector3 viewerPosition)
-        {
-            float viewDistanceSqr = _viewDistance * _viewDistance;
-            Vector3 viewerToChunk = chunkPosition - viewerPosition;
-            float distanceToChunkSqr = Vector3.SqrMagnitude(viewerToChunk);
-            return distanceToChunkSqr < viewDistanceSqr;
-        }
-
-        private void CreateChunk(Vector3 position)
-        {
-            GameObject newChunk = _chunkProvider.GetChunk(position, _chunkSize, _chunkParent);
-            _chunks.Add(newChunk);
-        }
+        private string GetChunkName(ChunkCoordinates coordinates)
+            => string.Format(CultureInfo.InvariantCulture, ChunkNameFormat, coordinates.X, coordinates.Y);
     }
 }

--- a/Assets/Scripts/Terrain/ChunkController.cs
+++ b/Assets/Scripts/Terrain/ChunkController.cs
@@ -1,0 +1,117 @@
+﻿using System.Collections.Generic;
+using PotentialRobot.Terrain.Generation;
+using UnityEngine;
+
+namespace PotentialRobot.Terrain
+{
+    public class ChunkController
+    {
+        private struct ChunkCoordinates
+        {
+            public int X { get; private set; }
+            public int Y { get; private set; }
+
+            public ChunkCoordinates(int x, int y)
+            {
+                X = x;
+                Y = y;
+            }
+
+            public static ChunkCoordinates operator +(ChunkCoordinates a, ChunkCoordinates b)
+                => new ChunkCoordinates(a.X + b.X, a.Y + b.Y);
+
+            public static ChunkCoordinates operator -(ChunkCoordinates a, ChunkCoordinates b)
+                => new ChunkCoordinates(a.X - b.X, a.Y - b.Y);
+        }
+
+        private readonly float _chunkSize;
+        private readonly float _viewDistance;
+        private readonly Transform _chunkParent;
+        private readonly List<GameObject> _chunks;
+        private readonly IChunkProvider _chunkProvider;
+
+        public ChunkController(Transform chunkParent, float chunkSize, float viewDistance)
+        {
+            _chunkParent = chunkParent;
+            _chunkSize = chunkSize;
+            _viewDistance = viewDistance;
+            _chunks = new List<GameObject>();
+            _chunkProvider = new ChunkProvider();
+        }
+
+        public void UpdateChunkVisibility(Vector3 viewerPosition)
+        {
+            CleanUpChunks();
+            CreateVisibleChunks(viewerPosition);
+        }
+
+        private void CleanUpChunks()
+        {
+            foreach (GameObject chunk in _chunks)
+                _chunkProvider.CleanUpChunk(chunk);
+        }
+
+        private void CreateVisibleChunks(Vector3 viewerPosition)
+        {
+            int viewDistanceInChunks = Mathf.RoundToInt(_viewDistance / _chunkSize);
+
+            for (int i = -viewDistanceInChunks; i <= viewDistanceInChunks; i++)
+            {
+                for (int j = -viewDistanceInChunks; j <= viewDistanceInChunks; j++)
+                {
+                    var chunkOffset = new ChunkCoordinates(i, j);
+                    ChunkCoordinates chunkCoordinates = ChunkCoordinatesFromOffset(viewerPosition, chunkOffset);
+                    CreateChunkIfVisible(chunkCoordinates, viewerPosition);
+                }
+            }
+        }
+
+        private ChunkCoordinates ChunkCoordinatesFromOffset(Vector3 viewerPosition, ChunkCoordinates chunkOffsetFromViewer)
+        {
+            ChunkCoordinates viewerCoordinates = PositionToChunkCoordinate(viewerPosition);
+            return viewerCoordinates + chunkOffsetFromViewer;
+        }
+
+        private ChunkCoordinates PositionToChunkCoordinate(Vector3 position)
+        {
+            int coordinateX = Mathf.RoundToInt(position.z / _chunkSize);
+            int coordinateY = Mathf.RoundToInt(position.x / _chunkSize);
+
+            return new ChunkCoordinates(coordinateX, coordinateY);
+        }
+
+        private void CreateChunkIfVisible(ChunkCoordinates coordinates, Vector3 viewerPosition)
+        {
+            Vector3 chunkPosition = CalculateChunkPosition(coordinates);
+            if (IsChunkVisible(chunkPosition, viewerPosition))
+                CreateChunk(chunkPosition);
+        }
+
+        private Vector3 CalculateChunkPosition(ChunkCoordinates coordinates)
+        {
+            float chunkX = coordinates.Y * _chunkSize;
+            float chunkY = 0;
+            float chunkZ = coordinates.X * _chunkSize;
+
+            return new Vector3(chunkX, chunkY, chunkZ);
+        }
+
+        /// <summary>
+        /// Calculates distance to chunk center, 
+        /// instead of distance to nearest point in chunk.
+        /// </summary>
+        private bool IsChunkVisible(Vector3 chunkPosition, Vector3 viewerPosition)
+        {
+            float viewDistanceSqr = _viewDistance * _viewDistance;
+            Vector3 viewerToChunk = chunkPosition - viewerPosition;
+            float distanceToChunkSqr = Vector3.SqrMagnitude(viewerToChunk);
+            return distanceToChunkSqr < viewDistanceSqr;
+        }
+
+        private void CreateChunk(Vector3 position)
+        {
+            GameObject newChunk = _chunkProvider.GetChunk(position, _chunkSize, _chunkParent);
+            _chunks.Add(newChunk);
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/ChunkController.cs.meta
+++ b/Assets/Scripts/Terrain/ChunkController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 51ec75454a4f3bb4b88c353af0492301
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/ChunkCoordinates.cs
+++ b/Assets/Scripts/Terrain/ChunkCoordinates.cs
@@ -1,0 +1,23 @@
+﻿namespace PotentialRobot.Terrain
+{
+    public struct ChunkCoordinates
+    {
+        /// <summary>
+        /// Unity's X axis, aka "right"
+        /// </summary>
+        public int X { get; private set; }
+        /// <summary>
+        /// Unity's Z axis, aka "forward"
+        /// </summary>
+        public int Y { get; private set; }
+
+        public ChunkCoordinates(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public static ChunkCoordinates operator +(ChunkCoordinates a, ChunkCoordinates b)
+            => new ChunkCoordinates(a.X + b.X, a.Y + b.Y);
+    }
+}

--- a/Assets/Scripts/Terrain/ChunkCoordinates.cs.meta
+++ b/Assets/Scripts/Terrain/ChunkCoordinates.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ab2fbb4a43475049a02fab2305892fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/ChunkPositionHelper.cs
+++ b/Assets/Scripts/Terrain/ChunkPositionHelper.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+
+namespace PotentialRobot.Terrain
+{
+    public class ChunkPositionHelper
+    {
+        private readonly float _chunkSize;
+
+        public ChunkPositionHelper(float chunkSize)
+        {
+            _chunkSize = chunkSize;
+        }
+
+        public Vector3 CoordinatesToPosition(ChunkCoordinates coordinates)
+        {
+            float chunkX = coordinates.X * _chunkSize;
+            float chunkY = 0;
+            float chunkZ = coordinates.Y * _chunkSize;
+
+            return new Vector3(chunkX, chunkY, chunkZ);
+        }
+
+        public ChunkCoordinates PositionToCoordinates(Vector3 position)
+        {
+            int coordinateX = Mathf.RoundToInt(position.x / _chunkSize);
+            int coordinateY = Mathf.RoundToInt(position.z / _chunkSize);
+
+            return new ChunkCoordinates(coordinateX, coordinateY);
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/ChunkPositionHelper.cs.meta
+++ b/Assets/Scripts/Terrain/ChunkPositionHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d076b1183072354492bfdf66e9fdf8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/ChunkVisibilityHelper.cs
+++ b/Assets/Scripts/Terrain/ChunkVisibilityHelper.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace PotentialRobot.Terrain
+{
+    public class ChunkVisibilityHelper
+    {
+        private readonly float _chunkSize;
+        private readonly float _viewDistance;
+        private readonly int _viewDistanceInChunks;
+        private readonly float _viewDistanceSqr;
+
+        public ChunkVisibilityHelper(float chunkSize, float viewDistance)
+        {
+            _chunkSize = chunkSize;
+            _viewDistance = viewDistance;
+            _viewDistanceInChunks = Mathf.RoundToInt(_viewDistance / _chunkSize);
+            _viewDistanceSqr = _viewDistance * _viewDistance;
+        }
+
+        public bool IsVisible(Vector3 chunkPosition, Vector3 viewerPosition)
+        {
+            Vector3 viewerToChunkCenter = chunkPosition - viewerPosition;
+            float distanceToChunkCenterSqr = Vector3.SqrMagnitude(viewerToChunkCenter);
+            return distanceToChunkCenterSqr < _viewDistanceSqr;
+        }
+
+        public IEnumerable<ChunkCoordinates> GetPotentiallyVisibleCoordinates(ChunkCoordinates viewerChunk)
+        {
+            for (int i = -_viewDistanceInChunks; i <= _viewDistanceInChunks; i++)
+            {
+                for (int j = -_viewDistanceInChunks; j <= _viewDistanceInChunks; j++)
+                {
+                    var chunkOffset = new ChunkCoordinates(i, j);
+                    yield return viewerChunk + chunkOffset;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/ChunkVisibilityHelper.cs.meta
+++ b/Assets/Scripts/Terrain/ChunkVisibilityHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55144e4093c368d4fae95096475bc830
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Generation.meta
+++ b/Assets/Scripts/Terrain/Generation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42dc82d1ccfdec54597d3c6340d8885e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Generation/ChunkProvider.cs
+++ b/Assets/Scripts/Terrain/Generation/ChunkProvider.cs
@@ -6,7 +6,7 @@ namespace PotentialRobot.Terrain.Generation
     {
         private static readonly Vector3 s_defaultRotationEuler = new Vector3(90f, 0f, 0f);
 
-        public GameObject GetNewChunk(Vector3 position, float size, Transform parent)
+        public GameObject GetChunk(Vector3 position, float size, Transform parent)
         {
             GameObject chunk = CreateNewChunk();
             InitChunk(chunk, position, size, parent);
@@ -25,6 +25,11 @@ namespace PotentialRobot.Terrain.Generation
             chunkTransform.localRotation = Quaternion.Euler(s_defaultRotationEuler);
             chunkTransform.position = position;
             chunkTransform.localScale = Vector3.one * size;
+        }
+
+        public void CleanUpChunk(GameObject chunk)
+        {
+            Object.Destroy(chunk);
         }
     }
 }

--- a/Assets/Scripts/Terrain/Generation/ChunkProvider.cs
+++ b/Assets/Scripts/Terrain/Generation/ChunkProvider.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+namespace PotentialRobot.Terrain.Generation
+{
+    public class ChunkProvider : IChunkProvider
+    {
+        private static readonly Vector3 s_defaultRotationEuler = new Vector3(90f, 0f, 0f);
+
+        public GameObject GetNewChunk(Vector3 position, float size, Transform parent)
+        {
+            GameObject chunk = CreateNewChunk();
+            InitChunk(chunk, position, size, parent);
+            return chunk;
+        }
+
+        private GameObject CreateNewChunk()
+        {
+            return GameObject.CreatePrimitive(PrimitiveType.Quad);
+        }
+
+        private void InitChunk(GameObject chunk, Vector3 position, float size, Transform parent)
+        {
+            Transform chunkTransform = chunk.transform;
+            chunkTransform.SetParent(parent);
+            chunkTransform.localRotation = Quaternion.Euler(s_defaultRotationEuler);
+            chunkTransform.position = position;
+            chunkTransform.localScale = Vector3.one * size;
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/Generation/ChunkProvider.cs
+++ b/Assets/Scripts/Terrain/Generation/ChunkProvider.cs
@@ -7,17 +7,21 @@ namespace PotentialRobot.Terrain.Generation
     {
         private static readonly Vector3 s_defaultRotationEuler = new Vector3(90f, 0f, 0f);
 
+        private readonly float _chunkSize;
+        private readonly Transform _chunkParent;
         private readonly Pool<GameObject> _chunkPool;
 
-        public ChunkProvider()
+        public ChunkProvider(Transform chunkParent, float chunkSize)
         {
+            _chunkParent = chunkParent;
+            _chunkSize = chunkSize;
             _chunkPool = new Pool<GameObject>(CreateNewChunk, ResetChunk);
         }
 
-        public GameObject GetChunk(Vector3 position, float size, Transform parent)
+        public GameObject GetChunk(Vector3 position)
         {
             GameObject chunk = _chunkPool.Lease();
-            InitChunk(chunk, position, size, parent);
+            InitChunk(chunk, position);
             return chunk;
         }
 
@@ -32,13 +36,13 @@ namespace PotentialRobot.Terrain.Generation
             return chunk;
         }
 
-        private void InitChunk(GameObject chunk, Vector3 position, float size, Transform parent)
+        private void InitChunk(GameObject chunk, Vector3 position)
         {
             Transform chunkTransform = chunk.transform;
-            chunkTransform.SetParent(parent);
+            chunkTransform.SetParent(_chunkParent);
             chunkTransform.localRotation = Quaternion.Euler(s_defaultRotationEuler);
             chunkTransform.localPosition = position;
-            chunkTransform.localScale = Vector3.one * size;
+            chunkTransform.localScale = Vector3.one * _chunkSize;
             chunk.SetActive(true);
         }
 

--- a/Assets/Scripts/Terrain/Generation/ChunkProvider.cs.meta
+++ b/Assets/Scripts/Terrain/Generation/ChunkProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d5044389cc3e3d4eac5e2a4c9ac0f71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/Generation/IChunkProvider.cs
+++ b/Assets/Scripts/Terrain/Generation/IChunkProvider.cs
@@ -4,7 +4,7 @@ namespace PotentialRobot.Terrain.Generation
 {
     public interface IChunkProvider
     {
-        GameObject GetChunk(Vector3 position, float size, Transform parent);
+        GameObject GetChunk(Vector3 position);
         void CleanUpChunk(GameObject chunk);
     }
 }

--- a/Assets/Scripts/Terrain/Generation/IChunkProvider.cs
+++ b/Assets/Scripts/Terrain/Generation/IChunkProvider.cs
@@ -4,6 +4,7 @@ namespace PotentialRobot.Terrain.Generation
 {
     public interface IChunkProvider
     {
-        GameObject GetNewChunk(Vector3 position, float size, Transform parent);
+        GameObject GetChunk(Vector3 position, float size, Transform parent);
+        void CleanUpChunk(GameObject chunk);
     }
 }

--- a/Assets/Scripts/Terrain/Generation/IChunkProvider.cs
+++ b/Assets/Scripts/Terrain/Generation/IChunkProvider.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace PotentialRobot.Terrain.Generation
+{
+    public interface IChunkProvider
+    {
+        GameObject GetNewChunk(Vector3 position, float size, Transform parent);
+    }
+}

--- a/Assets/Scripts/Terrain/Generation/IChunkProvider.cs.meta
+++ b/Assets/Scripts/Terrain/Generation/IChunkProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2dc2d5eaba0f1b44807837f74a772c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/IChunkController.cs
+++ b/Assets/Scripts/Terrain/IChunkController.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace PotentialRobot.Terrain
+{
+    public interface IChunkController
+    {
+        void UpdateChunkVisibility(Vector3 viewerPosition);
+    }
+}

--- a/Assets/Scripts/Terrain/IChunkController.cs.meta
+++ b/Assets/Scripts/Terrain/IChunkController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7bb816fe604dc04f84194d9e619985d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/TerrainController.cs
+++ b/Assets/Scripts/Terrain/TerrainController.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using PotentialRobot.Terrain.Generation;
+using UnityEngine;
+
+namespace PotentialRobot.Terrain
+{
+    public class TerrainController : MonoBehaviour
+    {
+        private struct ChunkCoordinates
+        {
+            public int X { get; private set; }
+            public int Y { get; private set; }
+
+            public ChunkCoordinates(int x, int y)
+            {
+                X = x;
+                Y = y;
+            }
+        }
+
+        [SerializeField]
+        private float _chunkSize = 1f;
+        [SerializeField]
+        private float _viewDistance = 5f;
+
+        private Transform _transform;
+        private List<GameObject> _chunks;
+        private IChunkProvider _chunkProvider;
+
+        private void Start()
+        {
+            Init();
+            CreateVisibleChunks();
+        }
+
+        private void Init()
+        {
+            _transform = transform;
+            _chunks = new List<GameObject>();
+            _chunkProvider = new ChunkProvider();
+        }
+
+        private void CreateVisibleChunks()
+        {
+            int viewDistanceInChunks = Mathf.RoundToInt(_viewDistance / _chunkSize);
+
+            for (int i = -viewDistanceInChunks; i <= viewDistanceInChunks; i++)
+            {
+                for (int j = -viewDistanceInChunks; j <= viewDistanceInChunks; j++)
+                {
+                    CreateChunkIfVisible(new ChunkCoordinates(i, j));
+                }
+            }
+        }
+
+        private void CreateChunkIfVisible(ChunkCoordinates coordinates)
+        {
+            Vector3 chunkPosition = CalculateChunkPosition(coordinates);
+            if (IsChunkVisible(chunkPosition))
+                CreateChunk(chunkPosition);
+        }
+
+        private Vector3 CalculateChunkPosition(ChunkCoordinates coordinates)
+        {
+            float chunkX = coordinates.Y * _chunkSize;
+            float chunkY = 0;
+            float chunkZ = coordinates.X * _chunkSize;
+
+            return new Vector3(chunkX, chunkY, chunkZ);
+        }
+
+        private bool IsChunkVisible(Vector3 chunkPosition)
+        {
+            Vector3 viewerPosition = Vector3.zero;
+            float viewDistanceSqr = _viewDistance * _viewDistance;
+
+            Vector3 viewerToChunk = chunkPosition - viewerPosition;
+            float distanceToChunkSqr = Vector3.SqrMagnitude(viewerToChunk);
+
+            return distanceToChunkSqr < viewDistanceSqr;
+        }
+
+        private void CreateChunk(Vector3 position)
+        {
+            GameObject newChunk = _chunkProvider.GetNewChunk(position, _chunkSize, _transform);
+            _chunks.Add(newChunk);
+        }
+    }
+}

--- a/Assets/Scripts/Terrain/TerrainController.cs
+++ b/Assets/Scripts/Terrain/TerrainController.cs
@@ -1,29 +1,9 @@
-using System.Collections.Generic;
-using PotentialRobot.Terrain.Generation;
 using UnityEngine;
 
 namespace PotentialRobot.Terrain
 {
     public class TerrainController : MonoBehaviour
     {
-        private struct ChunkCoordinates
-        {
-            public int X { get; private set; }
-            public int Y { get; private set; }
-
-            public ChunkCoordinates(int x, int y)
-            {
-                X = x;
-                Y = y;
-            }
-
-            public static ChunkCoordinates operator +(ChunkCoordinates a, ChunkCoordinates b)
-                => new ChunkCoordinates(a.X + b.X, a.Y + b.Y);
-
-            public static ChunkCoordinates operator -(ChunkCoordinates a, ChunkCoordinates b)
-                => new ChunkCoordinates(a.X - b.X, a.Y - b.Y);
-        }
-
         [SerializeField]
         private float _chunkSize = 1f;
         [SerializeField]
@@ -31,92 +11,16 @@ namespace PotentialRobot.Terrain
         [SerializeField]
         private Transform _viewer = null;
 
-        private Transform _transform;
-        private List<GameObject> _chunks;
-        private IChunkProvider _chunkProvider;
+        private ChunkController _chunkController;
 
         private void Start()
         {
-            Init();
-        }
-
-        private void Init()
-        {
-            _transform = transform;
-            _chunks = new List<GameObject>();
-            _chunkProvider = new ChunkProvider();
+            _chunkController = new ChunkController(transform, _chunkSize, _viewDistance);
         }
 
         private void Update()
         {
-            CleanUpChunks();
-            CreateVisibleChunks();
-        }
-
-        private void CleanUpChunks()
-        {
-            foreach (GameObject chunk in _chunks)
-                _chunkProvider.CleanUpChunk(chunk);
-        }
-
-        private void CreateVisibleChunks()
-        {
-            int viewDistanceInChunks = Mathf.RoundToInt(_viewDistance / _chunkSize);
-
-            for (int i = -viewDistanceInChunks; i <= viewDistanceInChunks; i++)
-            {
-                for (int j = -viewDistanceInChunks; j <= viewDistanceInChunks; j++)
-                {
-                    ChunkCoordinates viewerCoordinates = PositionToChunkCoordinate(_viewer.position);
-                    ChunkCoordinates chunkCoordinates = viewerCoordinates + new ChunkCoordinates(i, j);
-                    CreateChunkIfVisible(chunkCoordinates);
-                }
-            }
-        }
-
-        private ChunkCoordinates PositionToChunkCoordinate(Vector3 position)
-        {
-            int coordinateX = Mathf.RoundToInt(position.z / _chunkSize);
-            int coordinateY = Mathf.RoundToInt(position.x / _chunkSize);
-
-            return new ChunkCoordinates(coordinateX, coordinateY);
-        }
-
-        private void CreateChunkIfVisible(ChunkCoordinates coordinates)
-        {
-            Vector3 chunkPosition = CalculateChunkPosition(coordinates);
-            if (IsChunkVisible(chunkPosition))
-                CreateChunk(chunkPosition);
-        }
-
-        private Vector3 CalculateChunkPosition(ChunkCoordinates coordinates)
-        {
-            float chunkX = coordinates.Y * _chunkSize;
-            float chunkY = 0;
-            float chunkZ = coordinates.X * _chunkSize;
-
-            return new Vector3(chunkX, chunkY, chunkZ);
-        }
-
-        /// <summary>
-        /// Calculates distance to chunk center, 
-        /// instead of distance to nearest point in chunk.
-        /// </summary>
-        private bool IsChunkVisible(Vector3 chunkPosition)
-        {
-            Vector3 viewerPosition = _viewer.position;
-            float viewDistanceSqr = _viewDistance * _viewDistance;
-
-            Vector3 viewerToChunk = chunkPosition - viewerPosition;
-            float distanceToChunkSqr = Vector3.SqrMagnitude(viewerToChunk);
-
-            return distanceToChunkSqr < viewDistanceSqr;
-        }
-
-        private void CreateChunk(Vector3 position)
-        {
-            GameObject newChunk = _chunkProvider.GetChunk(position, _chunkSize, _transform);
-            _chunks.Add(newChunk);
+            _chunkController.UpdateChunkVisibility(_viewer.position);
         }
     }
 }

--- a/Assets/Scripts/Terrain/TerrainController.cs
+++ b/Assets/Scripts/Terrain/TerrainController.cs
@@ -11,7 +11,7 @@ namespace PotentialRobot.Terrain
         [SerializeField]
         private Transform _viewer = null;
 
-        private ChunkController _chunkController;
+        private IChunkController _chunkController;
 
         private void Start()
         {
@@ -20,7 +20,8 @@ namespace PotentialRobot.Terrain
 
         private void Update()
         {
-            _chunkController.UpdateChunkVisibility(_viewer.position);
+            var viewerPosition = new Vector3(_viewer.position.x, 0, _viewer.position.z);
+            _chunkController.UpdateChunkVisibility(viewerPosition);
         }
     }
 }

--- a/Assets/Scripts/Terrain/TerrainController.cs.meta
+++ b/Assets/Scripts/Terrain/TerrainController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7339f76633f1bc34baf59002888b5dc0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Problem description
- We want to be able to generate infinite terrain around the player as the player moves around

### New features
- Infinite (flat) terrain generation around the viewer within set view distance
- Generic Pool class for pooling items

### Changes
- `TerrainController`
  - Inspector-accessible settings and high level control
- `ChunkController`
  - Core logic for updating chunk visibility
- `ChunkProvider`
  - Chunk pooling and initialization
- `ChunkVisibilityHelper`
- `ChunkPositionHelper`

### Additional info
- PerlinNoise-based terrain generation and sloped terrain support will be added in upcoming PRs