### PR TITLE
Terrain generation 2: Slope

### DIFF
--- a/Assets/Scenes/TerrainGenerationTesting.unity
+++ b/Assets/Scenes/TerrainGenerationTesting.unity
@@ -324,9 +324,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7339f76633f1bc34baf59002888b5dc0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _viewer: {fileID: 113356281}
   _chunkSize: 10
   _viewDistance: 200
-  _viewer: {fileID: 113356281}
+  _slopeAngleDeg: 30
 --- !u!1 &999304457
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Terrain/ChunkController.cs
+++ b/Assets/Scripts/Terrain/ChunkController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using PotentialRobot.Terrain.Generation;
 using UnityEngine;
@@ -16,10 +17,33 @@ namespace PotentialRobot.Terrain
 
         public ChunkController(Transform chunkParent, float chunkSize, float viewDistance, float slopeAngleDeg)
         {
+            ThrowIfInvalidSettings(chunkSize, viewDistance, slopeAngleDeg);
+
             _chunkProvider = new ChunkProvider(chunkParent, chunkSize, slopeAngleDeg);
             _visibilityHelper = new ChunkVisibilityHelper(chunkSize, viewDistance);
             _positionHelper = new ChunkPositionHelper(chunkSize, slopeAngleDeg);
             _chunks = new Dictionary<ChunkCoordinates, GameObject>();
+        }
+
+        private void ThrowIfInvalidSettings(float chunkSize, float viewDistance, float slopeAngleDeg)
+        {
+            if (chunkSize < TerrainConstants.MinChunkSize || chunkSize > TerrainConstants.MaxChunkSize)
+            {
+                throw new ArgumentException(
+                    $"Value of {nameof(chunkSize)} ({chunkSize}) must be from {TerrainConstants.MinChunkSize} to {TerrainConstants.MaxChunkSize}");
+            }
+
+            if (viewDistance < TerrainConstants.MinViewDistance || viewDistance > TerrainConstants.MaxViewDistance)
+            {
+                throw new ArgumentException(
+                    $"Value of {nameof(viewDistance)} ({viewDistance}) must be from {TerrainConstants.MinViewDistance} to {TerrainConstants.MaxViewDistance}");
+            }
+
+            if (slopeAngleDeg < TerrainConstants.MinSlopeAngleDeg || slopeAngleDeg > TerrainConstants.MaxSlopeAngleDeg)
+            {
+                throw new ArgumentException(
+                    $"Value of {nameof(slopeAngleDeg)} ({slopeAngleDeg}) must be from {TerrainConstants.MinSlopeAngleDeg} to {TerrainConstants.MaxSlopeAngleDeg}");
+            }
         }
 
         public void UpdateChunkVisibility(Vector3 viewerPosition)

--- a/Assets/Scripts/Terrain/ChunkController.cs
+++ b/Assets/Scripts/Terrain/ChunkController.cs
@@ -16,7 +16,7 @@ namespace PotentialRobot.Terrain
 
         public ChunkController(Transform chunkParent, float chunkSize, float viewDistance, float slopeAngleDeg)
         {
-            _chunkProvider = new ChunkProvider(chunkParent, chunkSize);
+            _chunkProvider = new ChunkProvider(chunkParent, chunkSize, slopeAngleDeg);
             _visibilityHelper = new ChunkVisibilityHelper(chunkSize, viewDistance);
             _positionHelper = new ChunkPositionHelper(chunkSize, slopeAngleDeg);
             _chunks = new Dictionary<ChunkCoordinates, GameObject>();

--- a/Assets/Scripts/Terrain/ChunkController.cs
+++ b/Assets/Scripts/Terrain/ChunkController.cs
@@ -14,11 +14,11 @@ namespace PotentialRobot.Terrain
 
         private const string ChunkNameFormat = "Chunk [{0},{1}]";
 
-        public ChunkController(Transform chunkParent, float chunkSize, float viewDistance)
+        public ChunkController(Transform chunkParent, float chunkSize, float viewDistance, float slopeAngleDeg)
         {
             _chunkProvider = new ChunkProvider(chunkParent, chunkSize);
             _visibilityHelper = new ChunkVisibilityHelper(chunkSize, viewDistance);
-            _positionHelper = new ChunkPositionHelper(chunkSize);
+            _positionHelper = new ChunkPositionHelper(chunkSize, slopeAngleDeg);
             _chunks = new Dictionary<ChunkCoordinates, GameObject>();
         }
 

--- a/Assets/Scripts/Terrain/ChunkPositionHelper.cs
+++ b/Assets/Scripts/Terrain/ChunkPositionHelper.cs
@@ -5,16 +5,20 @@ namespace PotentialRobot.Terrain
     public class ChunkPositionHelper
     {
         private readonly float _chunkSize;
+        private readonly float _chunkHeight;
 
-        public ChunkPositionHelper(float chunkSize)
+        public ChunkPositionHelper(float chunkSize, float slopeAngleDeg)
         {
             _chunkSize = chunkSize;
+
+            float slopeAngleRad = Mathf.Deg2Rad * slopeAngleDeg;
+            _chunkHeight = Mathf.Tan(slopeAngleRad) * _chunkSize;
         }
 
         public Vector3 CoordinatesToPosition(ChunkCoordinates coordinates)
         {
             float chunkX = coordinates.X * _chunkSize;
-            float chunkY = 0;
+            float chunkY = coordinates.Y * -_chunkHeight;
             float chunkZ = coordinates.Y * _chunkSize;
 
             return new Vector3(chunkX, chunkY, chunkZ);

--- a/Assets/Scripts/Terrain/ChunkVisibilityHelper.cs
+++ b/Assets/Scripts/Terrain/ChunkVisibilityHelper.cs
@@ -20,6 +20,10 @@ namespace PotentialRobot.Terrain
 
         public bool IsVisible(Vector3 chunkPosition, Vector3 viewerPosition)
         {
+            // Ignore distance on y-axis
+            chunkPosition.y = 0;
+            viewerPosition.y = 0;
+
             Vector3 viewerToChunkCenter = chunkPosition - viewerPosition;
             float distanceToChunkCenterSqr = Vector3.SqrMagnitude(viewerToChunkCenter);
             return distanceToChunkCenterSqr < _viewDistanceSqr;

--- a/Assets/Scripts/Terrain/Generation/ChunkProvider.cs
+++ b/Assets/Scripts/Terrain/Generation/ChunkProvider.cs
@@ -5,24 +5,26 @@ namespace PotentialRobot.Terrain.Generation
 {
     public class ChunkProvider : IChunkProvider
     {
-        private static readonly Vector3 s_defaultRotationEuler = new Vector3(90f, 0f, 0f);
+        private const float DefaultRotationEulerX = 90f;
+        private const float DefaultRotationEulerY = 0;
+        private const float DefaultRotationEulerZ = 0;
 
-        private readonly float _chunkSize;
         private readonly Transform _chunkParent;
         private readonly Pool<GameObject> _chunkPool;
+        private readonly float _chunkSize;
+        private readonly float _slopeAngleDeg;
+        private readonly float _chunkLength;
 
-        public ChunkProvider(Transform chunkParent, float chunkSize)
+        public ChunkProvider(Transform chunkParent, float chunkSize, float slopeAngleDeg)
         {
             _chunkParent = chunkParent;
             _chunkSize = chunkSize;
+            _slopeAngleDeg = slopeAngleDeg;
             _chunkPool = new Pool<GameObject>(CreateNewChunk, ResetChunk);
-        }
 
-        public GameObject GetChunk(Vector3 position)
-        {
-            GameObject chunk = _chunkPool.Lease();
-            InitChunk(chunk, position);
-            return chunk;
+            float slopeAngleRad = Mathf.Deg2Rad * slopeAngleDeg;
+            float chunkHeight = Mathf.Tan(slopeAngleRad) * _chunkSize;
+            _chunkLength = Mathf.Sqrt((_chunkSize * _chunkSize) + (chunkHeight * chunkHeight));
         }
 
         private GameObject CreateNewChunk()
@@ -36,13 +38,28 @@ namespace PotentialRobot.Terrain.Generation
             return chunk;
         }
 
+        public GameObject GetChunk(Vector3 position)
+        {
+            GameObject chunk = _chunkPool.Lease();
+            InitChunk(chunk, position);
+            return chunk;
+        }
+
         private void InitChunk(GameObject chunk, Vector3 position)
         {
             Transform chunkTransform = chunk.transform;
             chunkTransform.SetParent(_chunkParent);
-            chunkTransform.localRotation = Quaternion.Euler(s_defaultRotationEuler);
             chunkTransform.localPosition = position;
-            chunkTransform.localScale = Vector3.one * _chunkSize;
+
+            var chunkRotationEuler = new Vector3(
+                DefaultRotationEulerX + _slopeAngleDeg,
+                DefaultRotationEulerY,
+                DefaultRotationEulerZ);
+            chunkTransform.localRotation = Quaternion.Euler(chunkRotationEuler);
+
+            var chunkScale = new Vector3(_chunkSize, _chunkLength, 1);
+            chunkTransform.localScale = chunkScale;
+
             chunk.SetActive(true);
         }
 

--- a/Assets/Scripts/Terrain/TerrainConstants.cs
+++ b/Assets/Scripts/Terrain/TerrainConstants.cs
@@ -1,0 +1,12 @@
+﻿namespace PotentialRobot.Terrain
+{
+    public static class TerrainConstants
+    {
+        public const float MinChunkSize = 1f;
+        public const float MaxChunkSize = 1000f;
+        public const float MinViewDistance = 1f;
+        public const float MaxViewDistance = 5000f;
+        public const float MinSlopeAngleDeg = 0f;
+        public const float MaxSlopeAngleDeg = 89f;
+    }
+}

--- a/Assets/Scripts/Terrain/TerrainConstants.cs.meta
+++ b/Assets/Scripts/Terrain/TerrainConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c926908d81710934781ca9c698bd2c36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Terrain/TerrainController.cs
+++ b/Assets/Scripts/Terrain/TerrainController.cs
@@ -10,18 +10,20 @@ namespace PotentialRobot.Terrain
         private float _viewDistance = 5f;
         [SerializeField]
         private Transform _viewer = null;
+        [SerializeField]
+        [Range(0, 89)]
+        private float _slopeAngleDeg = 30f;
 
         private IChunkController _chunkController;
 
         private void Start()
         {
-            _chunkController = new ChunkController(transform, _chunkSize, _viewDistance);
+            _chunkController = new ChunkController(transform, _chunkSize, _viewDistance, _slopeAngleDeg);
         }
 
         private void Update()
         {
-            var viewerPosition = new Vector3(_viewer.position.x, 0, _viewer.position.z);
-            _chunkController.UpdateChunkVisibility(viewerPosition);
+            _chunkController.UpdateChunkVisibility(_viewer.position);
         }
     }
 }

--- a/Assets/Scripts/Terrain/TerrainController.cs
+++ b/Assets/Scripts/Terrain/TerrainController.cs
@@ -5,13 +5,15 @@ namespace PotentialRobot.Terrain
     public class TerrainController : MonoBehaviour
     {
         [SerializeField]
-        private float _chunkSize = 1f;
-        [SerializeField]
-        private float _viewDistance = 5f;
-        [SerializeField]
         private Transform _viewer = null;
         [SerializeField]
-        [Range(0, 89)]
+        [Range(TerrainConstants.MinChunkSize, TerrainConstants.MaxChunkSize)]
+        private float _chunkSize = 1f;
+        [SerializeField]
+        [Range(TerrainConstants.MinViewDistance, TerrainConstants.MaxViewDistance)]
+        private float _viewDistance = 5f;
+        [SerializeField]
+        [Range(TerrainConstants.MinSlopeAngleDeg, TerrainConstants.MaxSlopeAngleDeg)]
         private float _slopeAngleDeg = 30f;
 
         private IChunkController _chunkController;


### PR DESCRIPTION
### Problem description
- We want the terrain generated around the player to be a slope instead of just flat

### New features
- Slope support for terrain generation

### Changes
- New inspector-accessible setting for the slope angle of the terrain in TerrainController
- ChunkPositionHelper now takes terrain slope into account
- ChunkProvider now takes terrain slope into account
- Added validation for min and max terrain settings values

### Additional info
- PerlinNoise-based terrain mesh generation to follow